### PR TITLE
Misc fixes

### DIFF
--- a/lib/iptables.js
+++ b/lib/iptables.js
@@ -53,15 +53,15 @@ REDIRECT   tcp  --  0.0.0.0/0.0.0.7      123.45.67.89         tcp dpt:80 redir p
 */
 
 var
-	R_IPT_IP  = /([\d.]+)/, // this is a weak match, use net.isIPv4
-	R_IPT_ROW = new RegExp(/^/ + [
+	IP_PATTERN = '([\\d.]+)', // this is a weak match, use net.isIPv4
+	R_IPT_ROW  = new RegExp('^' + [
 		'REDIRECT',
 		'tcp',
 		'--',
-		R_IPT_IP + '/' + R_IPT_IP,
-		R_IPT_IP,
-		/tcp dpt:(\d+) redir ports (\d+)/
-	].join(/\s+/) + /\s*$/);
+		IP_PATTERN + '/' + IP_PATTERN,
+		IP_PATTERN,
+		'tcp dpt:(\\d+) redir ports (\\d+)'
+	].join('\\s+') + '\\s*$');
 
 function IPTSet(ip, slots, ports) {
 	events.EventEmitter.call(this);
@@ -108,10 +108,10 @@ IPTSet.parse = function(input, ip, ports) {
 		if (ports.indexOf(+matches[4]) == -1) return;
 		result.push([
 			ip,
-			+matches[1].match(/\d+$/),
-			+matches[2].match(/\d+$/),
-			matches[4],
-			matches[5]
+			parseInt(matches[1].split('.').pop(), 10),
+			parseInt(matches[2].split('.').pop(), 10),
+			parseInt(matches[4], 10),
+			parseInt(matches[5], 10)
 		]);
 	});
 

--- a/package.json
+++ b/package.json
@@ -11,9 +11,8 @@
   },
   "main": "lib/ipcluster.js",
   "dependencies": {
-    "commander": "~2.8.1",
-    "q": "~1.4.1",
-    "lodash": "~3.10.1",
+    "q": "1.5.1",
+    "lodash": "4.17.11",
     "toobusy-js": "0.4.3"
   },
   "devDependencies": {


### PR DESCRIPTION
* The regular expression to parse IPTables rules was incorrect, we cannot generate a valid regexp patterns by concatenating regexp objects (there's plenty of bad `/` in the result)
* The dependencies are very old, and in particular, lodash (which we use only for the method `once`), is marked as a security vulnerability.

TODO: Test in app

@hvgirish @blakegong 