### PR TITLE
[PAN-2090] Integrate with codecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /node_modules
 .idea
 .editorconfig
+lib-cov/
+lcov.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jobs:
   include:
     - script: npm run lint
       name: Check Linting
-    - script: npm run test
+    - script: npm run test-with-coverage > lcov.txt
       name: Run Tests
 
 before_deploy:
@@ -26,3 +26,5 @@ deploy:
     condition: >-
       $(npm v -json | jq --raw-output '."dist-tags".latest') !=
       $(jq --raw-output .version package.json)
+after_success:
+  - bash <(curl -s https://raw.githubusercontent.com/zendesk/codecov-bash/master/codecov) -t $CODECOV_TOKEN -f lcov.txt

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+codecov:
+  require_ci_to_pass: yes
+coverage:
+  precision: 2
+  round: down
+  status:
+    project:
+      default:
+        target: 75%
+        threshold: 10% # Lower this when codecov becomes a mandatory pass
+    patch: off

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "scripts": {
     "test": "nodeunit test/**/*.js",
     "test-with-coverage": "jscoverage lib > /dev/null && WITH_COVERAGE=1 nodeunit --reporter lcov test/**/*.js",
-    "lint": "eslint **/*.js",
-    "setup-jscoverage": "jscoverage lib"
+    "lint": "eslint **/*.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,10 +21,13 @@
   },
   "devDependencies": {
     "eslint": "^6.1.0",
+    "jscoverage": "^0.6.0",
     "nodeunit": "^0.11.3"
   },
   "scripts": {
     "test": "nodeunit test/**/*.js",
-    "lint": "eslint **/*.js"
+    "test-with-coverage": "jscoverage lib > /dev/null && WITH_COVERAGE=1 nodeunit --reporter lcov test/**/*.js",
+    "lint": "eslint **/*.js",
+    "setup-jscoverage": "jscoverage lib"
   }
 }

--- a/test/nodeunit/test_hash_with_length.js
+++ b/test/nodeunit/test_hash_with_length.js
@@ -1,4 +1,6 @@
-var Hash = require('../../lib/HashWithLength');
+var Hash = process.env.WITH_COVERAGE ?
+	require('../../lib-cov/HashWithLength') :
+	require('../../lib/HashWithLength');
 
 exports.test_iteration = function(test) {
 

--- a/test/nodeunit/test_iptables.js
+++ b/test/nodeunit/test_iptables.js
@@ -1,4 +1,6 @@
-var IPTSet = require('../../lib/iptables');
+var IPTSet = process.env.WITH_COVERAGE ?
+	require('../../lib-cov/iptables') :
+	require('../../lib/iptables');
 
 IPTSet.log = console.log;
 

--- a/test/nodeunit/test_process_utils.js
+++ b/test/nodeunit/test_process_utils.js
@@ -1,5 +1,7 @@
 var Q = require('q');
-var process_util = require('../../lib/process_util');
+var process_util = process.env.WITH_COVERAGE ?
+	require('../../lib-cov/process_util') :
+	require('../../lib/process_util');
 
 exports.test_ps = function(test) {
 


### PR DESCRIPTION
### Context
This PR is to integrate codecov to `ipcluster`. Since we are still using `nodeunit` to run the tests, we have to use `jscoverage` to help to generate code coverage. Both are very old libraries so we should consider to migrate to more modern libraries.
http://www.vapidspace.com/coding/2014/01/31/code-coverage-metrics-with-nodeunit/

### Reference
@zendesk/fangorn

### Risk
Low, only integrate codecov