### PR TITLE
PAN-2170: Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner will be requested for
+# review when someone opens a pull request.
+*       @zendesk/fangorn

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+- [Useful guide to good commit messages](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
+- Commit messages should _not_ contain issue key. Put them in the PR instead. There is nothing wrong with having the issue IDs in the commits, but putting them only in the PR will save some characters per commit.
+- Each commit message should be a representative of what that commit contributes to the repo, not something unhelpful like "Add tests", or "Cleanup" or "JIRA-123FU". By looking at the message one should have a reasonable understanding of the purpose behind the commit.
+- You need 2 :+1:s and a green Travis build to merge Pull Requests.
+- For major changes, ping the team(s) on Slack owning this repo. Check Cerebro for ownership.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+### Context
+
+Describe why this PR exists, what problem you are addressing.
+
+Remember: PRs may be looked at by people outside your team because we have a shared codebase. Make 
+it easy for them to understand and contribute.
+
+
+### Approach
+
+Describe what the changeset is doing. Explain any unconventional approach used in the implementation.
+
+You may also use nice checklists if you're making a PR that is ongoing with a leftover TODO list:
+- [ ] Do this
+- [ ] And that
+- [ ] But also that!
+- [ ] Write tests
+
+If there's any caveat to the work, known accepted issues or risk, list them here too.
+
+
+### Dependencies and References
+
+Put here anything we can look at for reference:
+* jira ticket
+* zendesk tickets
+* dependent PRs
+* related PRs
+* direct link to code that's important to know/understand to make sense of the PR
+
+
+Mention your team, and subject matter experts (if any)
+
+
+### Risks
+
+:warning: DO NOT WRITE **None** :warning:
+
+This section is for the Samson deployers. It may not be you, or anyone from your team!
+Let deployers know what this PR is touching; e.g. "Increase number of request to scribe"


### PR DESCRIPTION
### Context
cf: https://zendesk.atlassian.net/wiki/spaces/ZOPIMENG/pages/944084035/Chat+Ownerships

### Approach
Update it to fangorn.

### Dependencies and References

https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
https://zendesk.atlassian.net/browse/PAN-2170

@zendesk/fangorn 

### Testing Different Account Types
N/A

### Test Plan
N/A

### Risks
Nil, just changing github CODEOWNERS files.