### PR TITLE
Move artifactory env vars to where it's needed

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,15 +20,10 @@ jobs:
     - uses: zendesk/setup-node@v2.5.1
       with:
         node-version: ${{ matrix.version }}
-    - name: node_js ${{ matrix.version }} ${{ matrix.task}}
-      env:
-        ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-        ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}
+    - name: node_js ${{ matrix.version }} ${{ matrix.task }}
       run: |
-        git config --global url."https://${{ secrets.ORG_GITHUB_TOKEN }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
-        curl -u "$ARTIFACTORY_USERNAME:$ARTIFACTORY_API_KEY" --fail https://zdrepo.jfrog.io/zdrepo/api/npm/npm/auth/zendesk >> ~/.npmrc
         npm install
-        npm run ${{ matrix.task}}
+        npm run ${{ matrix.task }}
   deploy:
     name: node_js-deploy
     needs: main
@@ -42,9 +37,13 @@ jobs:
         node-version: 12
     - name: publish
       if: github.ref == 'refs/heads/master'
+      env:
+        ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+        ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}
       run: |
         if $(npm v -json | jq --raw-output '."dist-tags".latest') != $(jq --raw-output .version package.json)
         then
+          curl -u "$ARTIFACTORY_USERNAME:$ARTIFACTORY_API_KEY" --fail https://zdrepo.jfrog.io/zdrepo/api/npm/npm/auth/zendesk >> ~/.npmrc
           npm install
           npm publish
         fi


### PR DESCRIPTION
### Context
Publishing is failing https://github.com/zendesk/ipcluster/runs/5067186278?check_suite_focus=true#step:4:8
and it seems that there has been no version bumps since the migration to github actions

### Approach
Since there are no dependencies that require artifactory, move the auth step to the `deploy` job instead.

### Risks
low: CI changes only, if the tests require the credentials the CI would fail.