### PR TITLE
Use os.tmpdir instead of os.tmpDir if it exists

### DIFF
--- a/lib/ipcluster.js
+++ b/lib/ipcluster.js
@@ -47,7 +47,10 @@ function tune_settings(settings) {
 		if (!('hostname' in settings) || !settings.hostname) {
 			throw new Error('invalid settings provided');
 		}
-		settings.uds = path.join(os.tmpDir(), settings.hostname + '.zsocket');
+
+		var tmpdir = (os.tmpdir && os.tmpdir()) || os.tmpDir();
+
+		settings.uds = path.join(tmpdir, settings.hostname + '.zsocket');
 	}
 
 	return settings;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Zendesk",
   "name": "@zendesk/ipcluster",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Context
os.tmpDir has been deprecated since Node.js 7, and is removed in Node.js 14

https://github.com/nodejs/node/pull/31169/files

### Approach
Check for `os.tmpdir` and use it instead of `os.tmpDir` if it exists.

### Dependencies and References
https://github.com/nodejs/node/pull/31169/files

### Risks
low: only increasing compatibility with more Node.js versions