### PR TITLE
Run tests with LTS node (18, 20), Deploy only to node 20

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,9 +10,8 @@ jobs:
           - lint
           - test-with-coverage > lcov.txt
         version:
-          - 8
-          - 10
-          - 12
+          - 18
+          - 20
     steps:
     - uses: zendesk/checkout@v2
       with:
@@ -34,7 +33,7 @@ jobs:
         fetch-depth: 0
     - uses: zendesk/setup-node@v2.5.1
       with:
-        node-version: 12
+        node-version: 20
     - name: publish
       if: github.ref == 'refs/heads/master'
       env:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Zendesk",
   "name": "@zendesk/ipcluster",
-  "version": "1.0.3",
+  "version": "1.1.3",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Context

Removing EOL NodeJS versions.

### Approach

Only maintain Node 18 & 20

### Dependencies and References

@zendesk/zeus 

### Risks

[Low] May impact public projects on node lower than 20