### PR TITLE
[SOJU-3550] Remove soju in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner will be requested for
 # review when someone opens a pull request.
-*       @zendesk/zeus @zendesk/soju
+*       @zendesk/zeus


### PR DESCRIPTION
### Context

Since Soju and Kopi are merged into the new Milo team, we have to rename any reference of Soju to Milo.

### Approach

Since ipcluster is used in chat dashboard mediator and Soju is no longer the owner, we can remove Soju from the CODEOWNERS.

### Dependencies and References

Put here anything we can look at for reference:
* jira ticket: https://zendesk.atlassian.net/browse/SOJU-3550
* zendesk tickets
* dependent PRs
* related PRs
* direct link to code that's important to know/understand to make sense of the PR


Mention your team, and subject matter experts (if any)


### Risks

None: not affecting production. Only CODEOWNERS update.